### PR TITLE
handle potential NULL values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ ENV USER_ID=1009
 WORKDIR /
 COPY --from=builder /app/backup-handler .
 COPY migrations migrations
-RUN mkdir -p -m 775 /var/backup-handler && microdnf install curl && microdnf clean all
+RUN mkdir -p -m 775 /var/backup-handler && microdnf install curl sqlite && microdnf clean all
 USER ${USER_ID}
 CMD ["/backup-handler"]
 EXPOSE 8890

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -3,6 +3,7 @@ package command
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 
@@ -143,10 +144,30 @@ func getUploadCredentials(secretKey types.NamespacedName) (*uploadCredentials, e
 		return nil, err
 	}
 
-	return &uploadCredentials{
-		bucket:       secret.StringData["bucket"],
-		region:       secret.StringData["region"],
-		accessID:     secret.StringData["access-id"],
-		accessSecret: secret.StringData["access-secret"],
-	}, nil
+	uploadCreds := &uploadCredentials{}
+	bucket, ok := secret.Data["bucket"]
+	if !ok {
+		return nil, errors.New("missing S3 bucket name")
+	}
+	uploadCreds.bucket = string(bucket)
+
+	region, ok := secret.Data["region"]
+	if !ok {
+		return nil, errors.New("missing S3 bucket")
+	}
+	uploadCreds.region = string(region)
+
+	accessID, ok := secret.Data["access-id"]
+	if !ok {
+		return nil, errors.New("missing S3 access ID")
+	}
+	uploadCreds.accessID = string(accessID)
+
+	accessSecret, ok := secret.Data["access-secret"]
+	if !ok {
+		return nil, errors.New("missing S3 access secret key")
+	}
+	uploadCreds.accessSecret = string(accessSecret)
+
+	return uploadCreds, nil
 }


### PR DESCRIPTION
The Golang `database/sql` package does not support converting NULL values
to specific types. This fix used sql.NullString type as a place holder.

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>