### PR TITLE
fix backup timestamps

### DIFF
--- a/migrations/0001_create_schema.up.sql
+++ b/migrations/0001_create_schema.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE backups (
-    created_at datetime,
-    updated_at datetime,
-    deleted_at datetime,
+    created_at varchar(32),
+    updated_at  varchar(32),
+    deleted_at  varchar(32),
     id varchar(72),
     name varchar(72),
     namespace varchar(60),

--- a/migrations/0002_create_restore.up.sql
+++ b/migrations/0002_create_restore.up.sql
@@ -1,7 +1,7 @@
 CREATE TABLE restores (
-    created_at datetime,
-    updated_at datetime,
-    deleted_at datetime,
+    created_at varchar(32),
+    updated_at varchar(32),
+    deleted_at varchar(32),
     id varchar(72),
     name varchar(72),
     namespace varchar(120),

--- a/service_helpers.go
+++ b/service_helpers.go
@@ -7,7 +7,7 @@ import (
 )
 
 func utcTime() *string {
-	t := time.Now().UTC().String()
+	t := time.Now().UTC().Format("2006-01-02 15:04:05 UTC")
 	return &t
 }
 


### PR DESCRIPTION
Store timestamps to sqlite3 as string as workaround for malformed times being returned when sqlite datetime is used

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>